### PR TITLE
yaml manifest fix

### DIFF
--- a/src/__tests__/fromYaml.test.js
+++ b/src/__tests__/fromYaml.test.js
@@ -43,6 +43,36 @@ pages:
   expect(parsedContent).toMatchSnapshot()
 })
 
+test("Valid navigation yaml format without homepage", () => {
+  const fileContent = `
+type: navigation
+order: 1
+title: About
+name: section-1
+pages:
+  - title: Home
+    url: /
+
+  - title: Page 2
+    url: /page-2/
+    pages:
+      - title: Example
+        url: /example/
+        pages:
+          - title: Nest a page
+            url: /nested/page/
+
+  - title: Diagrams
+    url: /diagrams/
+
+  - title: Hello World
+    url: /hello/
+`
+  const parsedContent = fromYaml(fileContent)
+
+  expect(parsedContent).toMatchSnapshot()
+})
+
 test("Valid yaml but not navigation file", () => {
   const fileContent = `
 name: Yaml file

--- a/src/fromYaml.js
+++ b/src/fromYaml.js
@@ -39,6 +39,30 @@ const convertPages = (pages) => {
   return convertedPages
 }
 
+
+/**
+ * Get the first defined path from a navigation tree structure.
+ * This search is breadth first.
+ *
+ * @param {Object[]} pages A nested list of page objects
+ *
+ * @returns {String} The first defined path value encountered.
+ */
+const getHomePage = pages => {
+  let found = pages.find(page => {
+    return page.path !== undefined
+  })
+
+  if (!found) {
+    pages.some(page => {
+      found = getHomePage(page.pages)
+      return found
+    })
+  }
+
+  return found.path
+}
+
 /**
  * A utility function for converting navigation data from a yaml file
  * into data for a parliamentNavigation GraphQL node object.
@@ -58,13 +82,19 @@ const fromYaml = (content) => {
     }
 
     const { order, title, name, url, pages } = object
+    const convertedPages = convertPages(pages)
 
+    let homePage = url
+    if (!homePage || homePage === undefined || homePage === '/') {
+      homePage = getHomePage(convertedPages)
+    }
+    
     return {
       section: name,
       title: title,
-      homePage: url,
+      homePage: homePage,
       order: order,
-      pages: convertPages(pages),
+      pages: convertedPages,
     }
   } catch (error) {
     //We should probably do something with the error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix for broken yaml manifest navigation
## Description
The homePage is not set and graphql query for homePage returns null, so navigating to site gets blank page.

<!--- Describe your changes in detail -->

When homePage / root url is undefined or '/' it will fetch the first available page in the nav as home page.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Required to support yaml manifest file.
## How Has This Been Tested?
Tested locally in develop and build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
