### PR TITLE
DEVEP-2694 Parse tabs metadata from Manifest

### DIFF
--- a/src/__tests__/__snapshots__/fromJson.test.js.snap
+++ b/src/__tests__/__snapshots__/fromJson.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`manifest with tabs 1`] = `
+Object {
+  "homePage": "DevRel/parliament-docs/master/README.md",
+  "order": 0,
+  "pages": Array [
+    Object {
+      "pages": Array [],
+      "path": "DevRel/parliament-docs/master/README.md",
+      "title": "Overview",
+    },
+  ],
+  "section": "Parliament Site",
+  "tabs": Array [
+    Object {
+      "path": "foo/",
+      "title": "foo",
+    },
+    Object {
+      "path": "foo/bar",
+      "title": "bar",
+    },
+  ],
+  "title": "Parliament Site",
+}
+`;
+
 exports[`manifest-docs.json content 1`] = `
 Object {
   "homePage": "DevRel/parliament-docs/master/README.md",
@@ -23,6 +49,7 @@ Object {
     },
   ],
   "section": "Parliament Site",
+  "tabs": Array [],
   "title": "Parliament Site",
 }
 `;
@@ -50,6 +77,7 @@ Object {
     },
   ],
   "section": "Parliament Site",
+  "tabs": Array [],
   "title": "Parliament Site",
 }
 `;

--- a/src/__tests__/__snapshots__/fromYaml.test.js.snap
+++ b/src/__tests__/__snapshots__/fromYaml.test.js.snap
@@ -39,6 +39,33 @@ Object {
     },
   ],
   "section": "section-1",
+  "tabs": Array [],
+  "title": "About",
+}
+`;
+
+exports[`Valid navigation yaml format with tabs 1`] = `
+Object {
+  "homePage": "/",
+  "order": 1,
+  "pages": Array [
+    Object {
+      "pages": Array [],
+      "path": "/",
+      "title": "Home",
+    },
+  ],
+  "section": "section-1",
+  "tabs": Array [
+    Object {
+      "path": "/foo/",
+      "title": "foo",
+    },
+    Object {
+      "path": "/foo/bar/",
+      "title": "bar",
+    },
+  ],
   "title": "About",
 }
 `;
@@ -82,6 +109,7 @@ Object {
     },
   ],
   "section": "section-1",
+  "tabs": Array [],
   "title": "About",
 }
 `;

--- a/src/__tests__/fromJson.test.js
+++ b/src/__tests__/fromJson.test.js
@@ -153,3 +153,41 @@ test("search for a homepage is breadth first", () => {
 
   expect(parsedContent.homePage).toBe("target/path.md")
 })
+
+test("manifest with tabs", () => {
+  const fileContent = `
+{
+  "name": "Parliament Site",
+  "version": "1.0.0",
+  "description": "Onboarding docs for Parliament",
+  "author": "DevRel Team",
+  "view_type": "mdbook",
+  "meta_keywords": "adobe, parliament",
+  "meta_description": "default description",
+  "publish_date": "30/08/2018",
+  "show_edit_github_banner": false,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "DevRel/parliament-docs/master/README.md",
+      "title": "Overview"
+    }
+  ],
+  "tabs": [
+    {
+      "title": "foo",
+      "path": "foo/"
+    },
+    {
+      "title": "bar",
+      "path": "foo/bar"
+    }
+  ]
+}
+`
+  const parsedContent = fromJson(fileContent)
+
+  expect(parsedContent).toMatchSnapshot()
+})

--- a/src/__tests__/fromYaml.test.js
+++ b/src/__tests__/fromYaml.test.js
@@ -73,6 +73,27 @@ pages:
   expect(parsedContent).toMatchSnapshot()
 })
 
+test("Valid navigation yaml format with tabs", () => {
+  const fileContent = `
+type: navigation
+order: 1
+title: About
+name: section-1
+pages:
+  - title: Home
+    url: /
+tabs:
+  - title: foo
+    url: /foo/
+
+  - title: bar
+    url: /foo/bar/
+`
+  const parsedContent = fromYaml(fileContent)
+
+  expect(parsedContent).toMatchSnapshot()
+})
+
 test("Valid yaml but not navigation file", () => {
   const fileContent = `
 name: Yaml file

--- a/src/fromJson.js
+++ b/src/fromJson.js
@@ -39,6 +39,29 @@ const convertPages = (pages, gitRepoInfo) => {
 }
 
 /**
+ * Converts an array of manifest-docs.json tab objects into a standard
+ * format for a parliamentNavigation GraphQL node object.
+ *
+ * @param {Object[]} tabs
+ *
+ * @returns {Object[]} A converted array
+ */
+const convertTabs = (tabs, gitRepoInfo) => {
+  if (tabs === undefined) {
+    return []
+  }
+
+  const convertedTabs = tabs.map(tab => {
+    return {
+      title: tab.title,
+      path: stripManifestPath(tab.path, gitRepoInfo),
+    }
+  })
+
+  return convertedTabs
+}
+
+/**
  * Get the first defined path from a navigation tree structure.
  * This search is breadth first.
  *
@@ -80,9 +103,10 @@ const fromJson = (content, gitRepoInfo) => {
       return
     }
 
-    const { name, pages } = object
+    const { name, pages, tabs } = object
 
     const convertedPages = convertPages(pages, gitRepoInfo)
+    const convertedTabs = convertTabs(tabs, gitRepoInfo)
 
     const homePage = getHomePage(convertedPages)
 
@@ -92,6 +116,7 @@ const fromJson = (content, gitRepoInfo) => {
       order: 0,
       pages: convertedPages,
       homePage: homePage,
+      tabs: convertedTabs,
     }
   } catch (error) {
     // We should probably do something with this error

--- a/src/fromYaml.js
+++ b/src/fromYaml.js
@@ -40,6 +40,30 @@ const convertPages = (pages, gitRepoInfo) => {
   return convertedPages
 }
 
+/**
+ * Converts an array of navigation tab objects into a standard
+ * format for a parliamentNavigation GraphQL node object.
+ *
+ * @param {Object[]} tabs
+ *
+ * @returns {Object[]} A converted array
+ */
+const convertTabs = (tabs, gitRepoInfo) => {
+  if (tabs === undefined) {
+    return []
+  }
+  const convertedTabs = tabs.map((tab) => {
+    const { title, url } = tab
+
+    return {
+      title: title,
+      path: stripManifestPath(url, gitRepoInfo)
+    }
+  })
+
+  return convertedTabs
+}
+
 
 /**
  * Get the first defined path from a navigation tree structure.
@@ -82,8 +106,9 @@ const fromYaml = (content, gitRepoInfo) => {
       return
     }
 
-    const { order, title, name, url, pages } = object
+    const { order, title, name, url, pages, tabs } = object
     const convertedPages = convertPages(pages, gitRepoInfo)
+    const convertedTabs = convertTabs(tabs, gitRepoInfo)
 
     let homePage = url
     if (!homePage || homePage === undefined || homePage === '/') {
@@ -96,6 +121,7 @@ const fromYaml = (content, gitRepoInfo) => {
       homePage: homePage,
       order: order,
       pages: convertedPages,
+      tabs: convertedTabs,
     }
   } catch (error) {
     //We should probably do something with the error


### PR DESCRIPTION
## Description

Extended the navigation parsers to parse metadata about tabs.

YAML example:

```yaml
type: navigation
order: 1
title: About
name: section-1
pages:
  - title: Home
    url: /
tabs:
  - title: foo
    url: /foo/

  - title: bar
    url: /foo/bar/
```

JSON example:
```json
{
  "name": "Parliament Site",
  "version": "1.0.0",
  "description": "Onboarding docs for Parliament",
  "author": "DevRel Team",
  "view_type": "mdbook",
  "meta_keywords": "adobe, parliament",
  "meta_description": "default description",
  "publish_date": "30/08/2018",
  "show_edit_github_banner": false,
  "base_path": "https://raw.githubusercontent.com",
  "pages": [
    {
      "importedFileName": "readme",
      "pages": [],
      "path": "DevRel/parliament-docs/master/README.md",
      "title": "Overview"
    }
  ],
  "tabs": [
    {
      "title": "foo",
      "path": "foo/"
    },
    {
      "title": "bar",
      "path": "foo/bar"
    }
  ]
}
```

## Related Issue

This change will be picked up by https://github.com/adobe/parliament-client-template to render additional tabs next to `Docs` and `Blog`

## Motivation and Context

Change discussed with core team
Motivation: some documentation needs to have external links that are highlighted in the page.

## How Has This Been Tested?

Tested the change locally by copying this plugin under the `plugins` folder in the `parliament-client-template` project.

The change is non breaking. If one does not specify any tabs, then an empty array is returned. 
The change I plan to make in the `parliament-client-template` will handle the empty array gracefully.

## Screenshots (if appropriate):

Not immediately related to this change, but giving a preview of what this change will be used for.

In the screenshot:
- the Swagger and Storybook tabs are external links
- the Workflow is an internal link

<img width="359" alt="Screenshot 2021-04-21 at 15 42 44" src="https://user-images.githubusercontent.com/1630716/115573084-5f362c00-a2b8-11eb-96cd-abc165b5139c.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
