### PR TITLE
🐛  DEVEP-2700: If doc folder name matches branch name stripManifestPath gets confused

### DIFF
--- a/src/ManifestUtils/index.js
+++ b/src/ManifestUtils/index.js
@@ -9,27 +9,31 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-function stripManifestPath(path, { org = '', name = '', branch = '' } = {}) {
+function stripManifestPath(path, { org = "", name = "", branch = "" } = {}) {
   if (!path) {
-    return ''
+    return ""
   }
   if (
-    path.startsWith('http://') ||
-    path.startsWith('https://') ||
-    (org === '' && name === '' && branch === '')
+    path.startsWith("http://") ||
+    path.startsWith("https://") ||
+    (org === "" && name === "" && branch === "")
   ) {
     return path
   }
   const prefix = [org, name, branch]
-  const splitPath = path.split('/').filter((item) => item !== '')
+  const splitPath = path.split("/").filter((item) => item !== "")
 
-  prefix.map((item) => {
-    if (item.toLocaleLowerCase() === splitPath[0].toLocaleLowerCase()) {
-      splitPath.shift()
-    }
-  })
-
-  return '/' + splitPath.join('/')
+  if (
+    splitPath.includes(org.toLocaleLowerCase()) ||
+    splitPath.includes(name.toLocaleLowerCase())
+  ) {
+    prefix.map((item) => {
+      if (item.toLocaleLowerCase() === splitPath[0].toLocaleLowerCase()) {
+        splitPath.shift()
+      }
+    })
+  }
+  return "/" + splitPath.join("/")
 }
 
 module.exports = stripManifestPath

--- a/src/ManifestUtils/test/ManifestUtils.test.js
+++ b/src/ManifestUtils/test/ManifestUtils.test.js
@@ -10,328 +10,346 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const stripManifestPath = require('../index')
+const stripManifestPath = require("../index")
 
 const manifest = {
-  author: 'Nathan Price',
-  base_path: 'https://raw.githubusercontent.com',
-  description: 'Analytics',
-  meta_description: 'default description',
-  meta_keywords: 'adobe, analytics',
-  name: 'Analytics',
+  author: "Nathan Price",
+  base_path: "https://raw.githubusercontent.com",
+  description: "Analytics",
+  meta_description: "default description",
+  meta_keywords: "adobe, analytics",
+  name: "Analytics",
   pages: [
     {
-      importedFileName: 'readme',
+      importedFileName: "readme",
       pages: [],
-      path: 'AdobeDocs/analytics-1.4-apis/master/README.md',
-      title: 'Overview'
+      path: "AdobeDocs/analytics-1.4-apis/master/README.md",
+      title: "Overview",
     },
     {
-      importedFileName: 'getting-started-2',
+      importedFileName: "getting-started-2",
       pages: [
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/reporting-api/index.md',
-          title: 'Reporting API'
+            "AdobeDocs/analytics-1.4-apis/master/docs/reporting-api/index.md",
+          title: "Reporting API",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
-          path: 'AdobeDocs/analytics-1.4-apis/master/docs/admin-api/index.md',
-          title: 'Admin API'
+          path: "AdobeDocs/analytics-1.4-apis/master/docs/admin-api/index.md",
+          title: "Admin API",
         },
         {
-          importedFileName: 'index',
-          pages: [],
-          path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/live-stream-api/index.md',
-          title: 'Live Stream'
-        },
-        {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/data-feeds-api/index.md',
-          title: 'Data Feeds'
+            "AdobeDocs/analytics-1.4-apis/master/docs/live-stream-api/index.md",
+          title: "Live Stream",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/data-sources-api/index.md',
-          title: 'Data Sources'
+            "AdobeDocs/analytics-1.4-apis/master/docs/data-feeds-api/index.md",
+          title: "Data Feeds",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/data-insertion-api/index.md',
-          title: 'Data Insertion'
+            "AdobeDocs/analytics-1.4-apis/master/docs/data-sources-api/index.md",
+          title: "Data Sources",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/data-warehouse-api/index.md',
-          title: 'Data Warehouse'
+            "AdobeDocs/analytics-1.4-apis/master/docs/data-insertion-api/index.md",
+          title: "Data Insertion",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/classifications-api/index.md',
-          title: 'Classifications'
+            "AdobeDocs/analytics-1.4-apis/master/docs/data-warehouse-api/index.md",
+          title: "Data Warehouse",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/calc-metrics-api/index.md',
-          title: 'Calculated Metrics'
+            "AdobeDocs/analytics-1.4-apis/master/docs/classifications-api/index.md",
+          title: "Classifications",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/segments-api/index.md',
-          title: 'Segments'
+            "AdobeDocs/analytics-1.4-apis/master/docs/calc-metrics-api/index.md",
+          title: "Calculated Metrics",
         },
         {
-          importedFileName: 'jwt',
+          importedFileName: "index",
           pages: [],
-          path: 'AdobeDocs/analytics-1.4-apis/master/jwt.md',
-          title: 'JWT Authentication'
-        }
+          path:
+            "AdobeDocs/analytics-1.4-apis/master/docs/segments-api/index.md",
+          title: "Segments",
+        },
+        {
+          importedFileName: "jwt",
+          pages: [],
+          path: "AdobeDocs/analytics-1.4-apis/master/jwt.md",
+          title: "JWT Authentication",
+        },
       ],
       path:
-        'AdobeDocs/analytics-1.4-apis/blob/master/docs/getting-started/getting-started-2.md',
-      title: 'Getting Started'
+        "AdobeDocs/analytics-1.4-apis/blob/master/docs/getting-started/getting-started-2.md",
+      title: "Getting Started",
     },
     {
-      importedFileName: 'index',
+      importedFileName: "index",
       pages: [
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/recommendations-api/index.md',
-          title: 'Legacy Recommendations API'
+            "AdobeDocs/analytics-1.4-apis/master/docs/recommendations-api/index.md",
+          title: "Legacy Recommendations API",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
-          path: 'AdobeDocs/analytics-1.4-apis/master/docs/target-api/index.md',
-          title: 'Legacy Target API'
+          path: "AdobeDocs/analytics-1.4-apis/master/docs/target-api/index.md",
+          title: "Legacy Target API",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
-          path: 'AdobeDocs/analytics-1.4-apis/master/docs/saint-api/index.md',
-          title: 'Legacy Saint API'
+          path: "AdobeDocs/analytics-1.4-apis/master/docs/saint-api/index.md",
+          title: "Legacy Saint API",
         },
         {
-          importedFileName: 'index',
-          pages: [],
-          path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/reporting-api-1.3/index.md',
-          title: 'Legacy Reporting API'
-        },
-        {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/admin-api-1.3/index.md',
-          title: 'Legacy Admin API'
+            "AdobeDocs/analytics-1.4-apis/master/docs/reporting-api-1.3/index.md",
+          title: "Legacy Reporting API",
         },
         {
-          importedFileName: 'index',
+          importedFileName: "index",
           pages: [],
           path:
-            'AdobeDocs/analytics-1.4-apis/master/docs/authentication/index.md',
-          title: 'Legacy Authentication'
-        }
+            "AdobeDocs/analytics-1.4-apis/master/docs/admin-api-1.3/index.md",
+          title: "Legacy Admin API",
+        },
+        {
+          importedFileName: "index",
+          pages: [],
+          path:
+            "AdobeDocs/analytics-1.4-apis/master/docs/authentication/index.md",
+          title: "Legacy Authentication",
+        },
       ],
-      path: 'AdobeDocs/analytics-1.4-apis/docs/APIEOL.md',
-      title: 'Legacy 1.3 APIs'
-    }
+      path: "AdobeDocs/analytics-1.4-apis/docs/APIEOL.md",
+      title: "Legacy 1.3 APIs",
+    },
   ],
-  publish_date: '11/11/2019',
+  publish_date: "11/11/2019",
   show_edit_github_banner: false,
-  version: '2.0.0',
-  view_type: 'mdbook'
+  version: "2.0.0",
+  view_type: "mdbook",
 }
 
-describe('stripManifestPath', () => {
-  it('is truthy', () => {
+describe("stripManifestPath", () => {
+  it("is truthy", () => {
     expect(stripManifestPath).toBeTruthy()
   })
-  it('empty to return empty', () => {
-    expect(stripManifestPath('', { org: 'fake', name: 'path' })).toEqual('')
+  it("empty to return empty", () => {
+    expect(stripManifestPath("", { org: "fake", name: "path" })).toEqual("")
   })
-  it('lower case to work', () => {
+  it("lower case to work", () => {
     expect(
-      stripManifestPath('adobedocs/adobeio-events/master/using.md', {
-        org: 'adobedocs',
-        name: 'adobeio-events',
-        branch: 'master'
+      stripManifestPath("adobedocs/adobeio-events/master/using.md", {
+        org: "adobedocs",
+        name: "adobeio-events",
+        branch: "master",
       })
-    ).toEqual('/using.md')
+    ).toEqual("/using.md")
   })
-  it('upper case to work', () => {
+  it("upper case to work", () => {
     expect(
-      stripManifestPath('AdobeDocs/adobeio-events/master/using.md', {
-        org: 'AdobeDocs',
-        name: 'adobeio-events',
-        branch: 'master'
+      stripManifestPath("AdobeDocs/adobeio-events/master/using.md", {
+        org: "AdobeDocs",
+        name: "adobeio-events",
+        branch: "master",
       })
-    ).toEqual('/using.md')
+    ).toEqual("/using.md")
   })
-  it('mixed case to work', () => {
+  it("mixed case to work", () => {
     expect(
-      stripManifestPath('AdobeDocs/adobeio-events/master/using.md', {
-        org: 'adobedocs',
-        name: 'adobeio-events',
-        branch: 'master'
+      stripManifestPath("AdobeDocs/adobeio-events/master/using.md", {
+        org: "adobedocs",
+        name: "adobeio-events",
+        branch: "master",
       })
-    ).toEqual('/using.md')
+    ).toEqual("/using.md")
   })
-  it('reversed mixed case to work', () => {
+  it("reversed mixed case to work", () => {
     expect(
-      stripManifestPath('adobedocs/adobeio-events/master/using.md', {
-        org: 'AdobeDocs',
-        name: 'adobeio-events',
-        branch: 'master'
+      stripManifestPath("adobedocs/adobeio-events/master/using.md", {
+        org: "AdobeDocs",
+        name: "adobeio-events",
+        branch: "master",
       })
-    ).toEqual('/using.md')
+    ).toEqual("/using.md")
   })
-  it('no url prefix to leave path unchanged', () => {
+  it("no url prefix to leave path unchanged", () => {
     expect(
-      stripManifestPath('adobedocs/adobeio-events/master/using.md', {})
-    ).toEqual('adobedocs/adobeio-events/master/using.md')
+      stripManifestPath("adobedocs/adobeio-events/master/using.md", {})
+    ).toEqual("adobedocs/adobeio-events/master/using.md")
   })
-  it('undefined url prefix to leave path unchanged', () => {
+  it("undefined url prefix to leave path unchanged", () => {
     expect(
-      stripManifestPath('adobedocs/adobeio-events/master/using.md')
-    ).toEqual('adobedocs/adobeio-events/master/using.md')
+      stripManifestPath("adobedocs/adobeio-events/master/using.md")
+    ).toEqual("adobedocs/adobeio-events/master/using.md")
   })
-  it('only repo name is in manifest path all options', () => {
+  it("only repo name is in manifest path all options", () => {
     expect(
-      stripManifestPath('stock-api-docs/docs/01-getting-started.md', {
-        org: 'adobe',
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("stock-api-docs/docs/01-getting-started.md", {
+        org: "adobe",
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('only repo name is in manifest path missing org', () => {
+  it("only repo name is in manifest path missing org", () => {
     expect(
-      stripManifestPath('stock-api-docs/docs/01-getting-started.md', {
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("stock-api-docs/docs/01-getting-started.md", {
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('only repo name is in manifest path missing branch', () => {
+  it("only repo name is in manifest path missing branch", () => {
     expect(
-      stripManifestPath('stock-api-docs/docs/01-getting-started.md', {
-        org: 'adobe',
-        name: 'stock-api-docs'
+      stripManifestPath("stock-api-docs/docs/01-getting-started.md", {
+        org: "adobe",
+        name: "stock-api-docs",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('only repo name is in manifest path missing org and branch', () => {
+  it("only repo name is in manifest path missing org and branch", () => {
     expect(
-      stripManifestPath('stock-api-docs/docs/01-getting-started.md', {
-        name: 'stock-api-docs'
+      stripManifestPath("stock-api-docs/docs/01-getting-started.md", {
+        name: "stock-api-docs",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('path does not include org, name or branch', () => {
+  it("path does not include org, name or branch", () => {
     expect(
-      stripManifestPath('/docs/01-getting-started.md', {
-        org: 'adobe',
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("/docs/01-getting-started.md", {
+        org: "adobe",
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('path does not include org, name or branch. No org passed', () => {
+  it("path does not include org, name or branch. No org passed", () => {
     expect(
-      stripManifestPath('/docs/01-getting-started.md', {
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("/docs/01-getting-started.md", {
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('path does not include org, name or branch', () => {
+  it("path does not include org, name or branch", () => {
     expect(
-      stripManifestPath('/docs/01-getting-started.md', {
-        org: 'adobe',
-        branch: 'master'
+      stripManifestPath("/docs/01-getting-started.md", {
+        org: "adobe",
+        branch: "master",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('path does not include org, name or branch', () => {
+  it("path does not include org, name or branch", () => {
     expect(
-      stripManifestPath('/docs/01-getting-started.md', {
-        org: 'adobe',
-        name: 'stock-api-docs'
+      stripManifestPath("/docs/01-getting-started.md", {
+        org: "adobe",
+        name: "stock-api-docs",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('path does not include org, name or branch', () => {
+  it("path does not include org, name or branch", () => {
     expect(
-      stripManifestPath('/docs/01-getting-started.md', {
-        org: 'adobe',
-        branch: 'master'
+      stripManifestPath("/docs/01-getting-started.md", {
+        org: "adobe",
+        branch: "master",
       })
-    ).toEqual('/docs/01-getting-started.md')
+    ).toEqual("/docs/01-getting-started.md")
   })
-  it('remote link with org in url', () => {
+  it("remote link with org in url", () => {
     expect(
-      stripManifestPath('https://adobe.io/authentication', {
-        org: 'adobe',
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("https://adobe.io/authentication", {
+        org: "adobe",
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('https://adobe.io/authentication')
+    ).toEqual("https://adobe.io/authentication")
   })
-  it('remote link without org in url', () => {
+  it("remote link without org in url", () => {
     expect(
-      stripManifestPath('https://adobe.io/authentication', {
-        org: 'adobedocs',
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("https://adobe.io/authentication", {
+        org: "adobedocs",
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('https://adobe.io/authentication')
+    ).toEqual("https://adobe.io/authentication")
   })
-  it('local reference path without org, repo and branch', () => {
+  it("local reference path without org, repo and branch", () => {
     expect(
-      stripManifestPath('README.md', {
-        org: 'adobedocs',
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("README.md", {
+        org: "adobedocs",
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('/README.md')
+    ).toEqual("/README.md")
   })
-  it('complex local reference path without org, repo and branch', () => {
+  it("complex local reference path without org, repo and branch", () => {
     expect(
-      stripManifestPath('docs/reference/openapi.json', {
-        org: 'adobedocs',
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("docs/reference/openapi.json", {
+        org: "adobedocs",
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('/docs/reference/openapi.json')
+    ).toEqual("/docs/reference/openapi.json")
   })
-  it('complex local reference path leading /', () => {
+  it("complex local reference path leading /", () => {
     expect(
-      stripManifestPath('/onboarding.md', {
-        org: 'adobedocs',
-        name: 'stock-api-docs',
-        branch: 'master'
+      stripManifestPath("/onboarding.md", {
+        org: "adobedocs",
+        name: "stock-api-docs",
+        branch: "master",
       })
-    ).toEqual('/onboarding.md')
+    ).toEqual("/onboarding.md")
+  })
+  it("folder name matches branch name, full git info in path", () => {
+    expect(
+      stripManifestPath("/adobedocs/stock-api-docs/docs/docs/onboarding.md", {
+        org: "adobedocs",
+        name: "stock-api-docs",
+        branch: "docs",
+      })
+    ).toEqual("/docs/onboarding.md")
+  })
+  it("folder name matches branch name, not full git info in path", () => {
+    expect(
+      stripManifestPath("/docs/onboarding.md", {
+        org: "adobedocs",
+        name: "stock-api-docs",
+        branch: "docs",
+      })
+    ).toEqual("/docs/onboarding.md")
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If doc folder name matches branch name stripManifestPath gets confused

## Related Issue

DEVEP-2700

## Motivation and Context

Some folks are onboarding their projects using a "docs" branch which then includes a "docs" folder so stripManifestPath accidentally removes the folder name.

## How Has This Been Tested?

Assume the repos is https://github.com/adobedocs/stock-api-docs and the branch name is `docs`.

- If the manifest path is `/adobedocs/stock-api-docs/docs/docs/onboarding.md` it becomes `/docs/onboarding.md` which is correct.
- If the manifest path is `/docs/onboarding.md` it becomes `/docs/onboarding.md` which is correct.
- If the manifest path is `/adobedocs/stock-api-docs/docs/onboarding.md` it becomes `/onboarding.md` which is not correct but I know of no way around this.

Added additional unit tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
