### PR TITLE
Allow users to configure openapi engine in manifest file

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,7 +12,7 @@
 
 const fromJson = require("./src/fromJson")
 const fromYaml = require("./src/fromYaml")
-const reduceGraphQLToJson = require("./src/utils")
+const { reduceGraphQLToJson } = require("./src/utils")
 
 /**
  * Callback for creating graphql nodes from project navigation files.

--- a/src/__tests__/__snapshots__/fromJson.test.js.snap
+++ b/src/__tests__/__snapshots__/fromJson.test.js.snap
@@ -1,9 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`manifest with invalid openApiEngine 1`] = `
+Object {
+  "homePage": "DevRel/parliament-docs/master/README.md",
+  "issues": "https://github.com/adobe/parliament-transformer-navigation/issues",
+  "openApiEngine": "redoc",
+  "order": 0,
+  "pages": Array [
+    Object {
+      "pages": Array [],
+      "path": "DevRel/parliament-docs/master/README.md",
+      "title": "Overview",
+    },
+  ],
+  "section": "Parliament Site",
+  "tabs": Array [
+    Object {
+      "path": "foo/",
+      "title": "foo",
+    },
+    Object {
+      "path": "foo/bar",
+      "title": "bar",
+    },
+  ],
+  "title": "Parliament Site",
+}
+`;
+
 exports[`manifest with issues 1`] = `
 Object {
   "homePage": "DevRel/parliament-docs/master/README.md",
   "issues": "https://github.com/adobe/parliament-transformer-navigation/issues",
+  "openApiEngine": "redoc",
+  "order": 0,
+  "pages": Array [
+    Object {
+      "pages": Array [],
+      "path": "DevRel/parliament-docs/master/README.md",
+      "title": "Overview",
+    },
+  ],
+  "section": "Parliament Site",
+  "tabs": Array [
+    Object {
+      "path": "foo/",
+      "title": "foo",
+    },
+    Object {
+      "path": "foo/bar",
+      "title": "bar",
+    },
+  ],
+  "title": "Parliament Site",
+}
+`;
+
+exports[`manifest with openApiEngine 1`] = `
+Object {
+  "homePage": "DevRel/parliament-docs/master/README.md",
+  "issues": "https://github.com/adobe/parliament-transformer-navigation/issues",
+  "openApiEngine": "swagger-ui",
   "order": 0,
   "pages": Array [
     Object {
@@ -31,6 +88,7 @@ exports[`manifest with tabs 1`] = `
 Object {
   "homePage": "DevRel/parliament-docs/master/README.md",
   "issues": null,
+  "openApiEngine": "redoc",
   "order": 0,
   "pages": Array [
     Object {
@@ -58,6 +116,7 @@ exports[`manifest without issues 1`] = `
 Object {
   "homePage": "DevRel/parliament-docs/master/README.md",
   "issues": null,
+  "openApiEngine": "redoc",
   "order": 0,
   "pages": Array [
     Object {
@@ -85,6 +144,7 @@ exports[`manifest-docs.json content 1`] = `
 Object {
   "homePage": "DevRel/parliament-docs/master/README.md",
   "issues": null,
+  "openApiEngine": "redoc",
   "order": 0,
   "pages": Array [
     Object {
@@ -114,6 +174,7 @@ exports[`missing pages property 1`] = `
 Object {
   "homePage": "DevRel/parliament-docs/master/README.md",
   "issues": null,
+  "openApiEngine": "redoc",
   "order": 0,
   "pages": Array [
     Object {

--- a/src/__tests__/__snapshots__/fromYaml.test.js.snap
+++ b/src/__tests__/__snapshots__/fromYaml.test.js.snap
@@ -4,6 +4,53 @@ exports[`Magento devdocs navigation format 1`] = `
 Object {
   "homePage": "/",
   "issues": null,
+  "openApiEngine": "redoc",
+  "order": 1,
+  "pages": Array [
+    Object {
+      "pages": Array [],
+      "path": "/",
+      "title": "Home",
+    },
+    Object {
+      "pages": Array [
+        Object {
+          "pages": Array [
+            Object {
+              "pages": Array [],
+              "path": "/nested/page/",
+              "title": "Nest a page",
+            },
+          ],
+          "path": "/example/",
+          "title": "Example",
+        },
+      ],
+      "path": "/page-2/",
+      "title": "Page 2",
+    },
+    Object {
+      "pages": Array [],
+      "path": "/diagrams/",
+      "title": "Diagrams",
+    },
+    Object {
+      "pages": Array [],
+      "path": "/hello/",
+      "title": "Hello World",
+    },
+  ],
+  "section": "section-1",
+  "tabs": Array [],
+  "title": "About",
+}
+`;
+
+exports[`Valid navigation yaml format with invalid openApiEngine 1`] = `
+Object {
+  "homePage": "/",
+  "issues": null,
+  "openApiEngine": "redoc",
   "order": 1,
   "pages": Array [
     Object {
@@ -49,6 +96,53 @@ exports[`Valid navigation yaml format with issues 1`] = `
 Object {
   "homePage": "/",
   "issues": "https://github.com/adobe/parliament-transformer-navigation/issues",
+  "openApiEngine": "redoc",
+  "order": 1,
+  "pages": Array [
+    Object {
+      "pages": Array [],
+      "path": "/",
+      "title": "Home",
+    },
+    Object {
+      "pages": Array [
+        Object {
+          "pages": Array [
+            Object {
+              "pages": Array [],
+              "path": "/nested/page/",
+              "title": "Nest a page",
+            },
+          ],
+          "path": "/example/",
+          "title": "Example",
+        },
+      ],
+      "path": "/page-2/",
+      "title": "Page 2",
+    },
+    Object {
+      "pages": Array [],
+      "path": "/diagrams/",
+      "title": "Diagrams",
+    },
+    Object {
+      "pages": Array [],
+      "path": "/hello/",
+      "title": "Hello World",
+    },
+  ],
+  "section": "section-1",
+  "tabs": Array [],
+  "title": "About",
+}
+`;
+
+exports[`Valid navigation yaml format with openApiEngine 1`] = `
+Object {
+  "homePage": "/",
+  "issues": null,
+  "openApiEngine": "swagger-ui",
   "order": 1,
   "pages": Array [
     Object {
@@ -94,6 +188,7 @@ exports[`Valid navigation yaml format with tabs 1`] = `
 Object {
   "homePage": "/",
   "issues": null,
+  "openApiEngine": "redoc",
   "order": 1,
   "pages": Array [
     Object {
@@ -121,6 +216,7 @@ exports[`Valid navigation yaml format without homepage 1`] = `
 Object {
   "homePage": "/",
   "issues": null,
+  "openApiEngine": "redoc",
   "order": 1,
   "pages": Array [
     Object {
@@ -166,6 +262,7 @@ exports[`Valid navigation yaml format without issues 1`] = `
 Object {
   "homePage": "/",
   "issues": null,
+  "openApiEngine": "redoc",
   "order": 1,
   "pages": Array [
     Object {

--- a/src/__tests__/fromJson.test.js
+++ b/src/__tests__/fromJson.test.js
@@ -268,3 +268,83 @@ test("manifest with issues", () => {
 
   expect(parsedContent).toMatchSnapshot()
 })
+
+test("manifest with openApiEngine", () => {
+  const fileContent = `
+{
+  "name": "Parliament Site",
+  "version": "1.0.0",
+  "description": "Onboarding docs for Parliament",
+  "author": "DevRel Team",
+  "view_type": "mdbook",
+  "meta_keywords": "adobe, parliament",
+  "meta_description": "default description",
+  "publish_date": "30/08/2018",
+  "show_edit_github_banner": false,
+  "base_path": "https://raw.githubusercontent.com",
+  "issues": "https://github.com/adobe/parliament-transformer-navigation/issues",
+  "openApiEngine": "swagger-ui",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "DevRel/parliament-docs/master/README.md",
+      "title": "Overview"
+    }
+  ],
+  "tabs": [
+    {
+      "title": "foo",
+      "path": "foo/"
+    },
+    {
+      "title": "bar",
+      "path": "foo/bar"
+    }
+  ]
+}
+`
+  const parsedContent = fromJson(fileContent)
+
+  expect(parsedContent).toMatchSnapshot()
+})
+
+test("manifest with invalid openApiEngine", () => {
+  const fileContent = `
+{
+  "name": "Parliament Site",
+  "version": "1.0.0",
+  "description": "Onboarding docs for Parliament",
+  "author": "DevRel Team",
+  "view_type": "mdbook",
+  "meta_keywords": "adobe, parliament",
+  "meta_description": "default description",
+  "publish_date": "30/08/2018",
+  "show_edit_github_banner": false,
+  "base_path": "https://raw.githubusercontent.com",
+  "issues": "https://github.com/adobe/parliament-transformer-navigation/issues",
+  "openApiEngine": "foobar",
+  "pages": [
+    {
+      "importedFileName": "readme",
+      "pages": [],
+      "path": "DevRel/parliament-docs/master/README.md",
+      "title": "Overview"
+    }
+  ],
+  "tabs": [
+    {
+      "title": "foo",
+      "path": "foo/"
+    },
+    {
+      "title": "bar",
+      "path": "foo/bar"
+    }
+  ]
+}
+`
+  const parsedContent = fromJson(fileContent)
+
+  expect(parsedContent).toMatchSnapshot()
+})

--- a/src/__tests__/fromYaml.test.js
+++ b/src/__tests__/fromYaml.test.js
@@ -187,3 +187,65 @@ pages:
 
   expect(parsedContent).toMatchSnapshot()
 })
+
+test("Valid navigation yaml format with openApiEngine", () => {
+  const fileContent = `
+type: navigation
+order: 1
+title: About
+name: section-1
+openApiEngine: swagger-ui
+pages:
+  - title: Home
+    url: /
+
+  - title: Page 2
+    url: /page-2/
+    pages:
+      - title: Example
+        url: /example/
+        pages:
+          - title: Nest a page
+            url: /nested/page/
+
+  - title: Diagrams
+    url: /diagrams/
+
+  - title: Hello World
+    url: /hello/
+`
+  const parsedContent = fromYaml(fileContent)
+
+  expect(parsedContent).toMatchSnapshot()
+})
+
+test("Valid navigation yaml format with invalid openApiEngine", () => {
+  const fileContent = `
+type: navigation
+order: 1
+title: About
+name: section-1
+openApiEngine: foobar
+pages:
+  - title: Home
+    url: /
+
+  - title: Page 2
+    url: /page-2/
+    pages:
+      - title: Example
+        url: /example/
+        pages:
+          - title: Nest a page
+            url: /nested/page/
+
+  - title: Diagrams
+    url: /diagrams/
+
+  - title: Hello World
+    url: /hello/
+`
+  const parsedContent = fromYaml(fileContent)
+
+  expect(parsedContent).toMatchSnapshot()
+})

--- a/src/__tests__/utiils.test.js
+++ b/src/__tests__/utiils.test.js
@@ -10,7 +10,7 @@
  *  governing permissions and limitations under the License.
  */
 
-const reduceGraphQLToJson = require("../utils")
+const { reduceGraphQLToJson, validateOpenApiEngine } = require("../utils")
 
 test("Magento devdocs navigation format", () => {
   const nodes = [
@@ -197,4 +197,13 @@ test("manifest-docs.json format", () => {
   ]
 
   expect(reduceGraphQLToJson(nodes)).toMatchSnapshot()
+})
+
+test("manifest-docs.json format", () => {
+  expect(validateOpenApiEngine("redoc")).toEqual("redoc")
+  expect(validateOpenApiEngine("swagger-ui")).toEqual("swagger-ui")
+  expect(validateOpenApiEngine("foobar")).toEqual("redoc")
+  expect(validateOpenApiEngine("")).toEqual("redoc")
+  expect(validateOpenApiEngine(null)).toEqual("redoc")
+  expect(validateOpenApiEngine(undefined)).toEqual("redoc")
 })

--- a/src/fromJson.js
+++ b/src/fromJson.js
@@ -21,6 +21,7 @@
  * @returns {Object[]} A converted array
  */
 const stripManifestPath = require("./ManifestUtils")
+const { validateOpenApiEngine } = require("./utils")
 
 const convertPages = (pages, gitRepoInfo) => {
   if (pages === undefined) {
@@ -103,7 +104,7 @@ const fromJson = (content, gitRepoInfo) => {
       return
     }
 
-    const { name, pages, tabs, issues = null } = object
+    const { name, pages, tabs, issues = null, openApiEngine = "redoc" } = object
 
     const convertedPages = convertPages(pages, gitRepoInfo)
     const convertedTabs = convertTabs(tabs, gitRepoInfo)
@@ -118,6 +119,7 @@ const fromJson = (content, gitRepoInfo) => {
       pages: convertedPages,
       homePage: homePage,
       tabs: convertedTabs,
+      openApiEngine: validateOpenApiEngine(openApiEngine),
     }
   } catch (error) {
     // We should probably do something with this error

--- a/src/fromYaml.js
+++ b/src/fromYaml.js
@@ -10,6 +10,7 @@
  *  governing permissions and limitations under the License.
  */
 const stripManifestPath = require("./ManifestUtils")
+const { validateOpenApiEngine } = require("./utils")
 
 const yamlParser = require("yaml")
 
@@ -105,7 +106,16 @@ const fromYaml = (content, gitRepoInfo) => {
       return
     }
 
-    const { order, title, name, url, pages, tabs, issues = null } = object
+    const {
+      order,
+      title,
+      name,
+      url,
+      pages,
+      tabs,
+      issues = null,
+      openApiEngine = "redoc",
+    } = object
     const convertedPages = convertPages(pages, gitRepoInfo)
     const convertedTabs = convertTabs(tabs, gitRepoInfo)
 
@@ -122,6 +132,7 @@ const fromYaml = (content, gitRepoInfo) => {
       issues: issues,
       pages: convertedPages,
       tabs: convertedTabs,
+      openApiEngine: validateOpenApiEngine(openApiEngine),
     }
   } catch (error) {
     //We should probably do something with the error

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,6 +12,8 @@
 
 const { GraphQLJSON } = require("gatsby/graphql")
 
+const openApiEngineTypes = ["redoc", "swagger-ui"]
+
 const reduceGraphQLToJson = (nodes) => {
   return nodes
     .map(({ id, parent, children, internal, ...rest }) => Object.keys(rest))
@@ -19,4 +21,8 @@ const reduceGraphQLToJson = (nodes) => {
     .reduce((o, name) => ({ ...o, [name]: GraphQLJSON }), {})
 }
 
-module.exports = reduceGraphQLToJson
+const validateOpenApiEngine = (engine) => {
+  return openApiEngineTypes.includes(engine) ? engine : "redoc"
+}
+
+module.exports = { reduceGraphQLToJson, validateOpenApiEngine }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds 'openApiEngine' key to manifest transformation

## Related Issue

DEVEP-2833

## Motivation and Context

Allows users to switch to using a different open api rendering engine based on key in manifest file.

## How Has This Been Tested?

- added tests
- Ran with gatsby develop

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
